### PR TITLE
fix: [IF-FINDING-002] Slashing parameters can be modified to unexpected values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+* (x/slashing) [#1](https://github.com/xrplevm/cosmos-sdk/pull/1) [IF-FINDING-002] Slashing parameters can be modified to unexpected values
+
+## [v0.50.11-evmos](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.50.11-evmos) - 2025-01-21
+
 ## [v0.50.9-evmos](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.50.9-evmos) - 2024-08-07
 
 

--- a/tests/integration/evidence/keeper/infraction_test.go
+++ b/tests/integration/evidence/keeper/infraction_test.go
@@ -224,7 +224,8 @@ func TestHandleDoubleSign(t *testing.T) {
 
 	// tokens should be decreased
 	newTokens := val.GetTokens()
-	assert.Assert(t, newTokens.LT(oldTokens))
+	// NOTE: IF-FINDING-002 Assert that slashed fraction double sign is 0
+	assert.Assert(t, newTokens.LTE(oldTokens))
 
 	// submit duplicate evidence
 	assert.NilError(t, f.evidenceKeeper.BeginBlocker(ctx))

--- a/tests/integration/slashing/keeper/keeper_test.go
+++ b/tests/integration/slashing/keeper/keeper_test.go
@@ -321,7 +321,8 @@ func TestHandleAlreadyJailed(t *testing.T) {
 	assert.Equal(t, stakingtypes.Unbonding, validator.GetStatus())
 
 	// validator should have been slashed
-	resultingTokens := amt.Sub(f.stakingKeeper.TokensFromConsensusPower(f.ctx, 1))
+	// NOTE: IF-FINDING-002 Assert that slashed fraction downtime is 0
+	resultingTokens := amt.Sub(f.stakingKeeper.TokensFromConsensusPower(f.ctx, 0))
 	assert.DeepEqual(t, resultingTokens, validator.GetTokens())
 
 	// another block missed

--- a/x/slashing/keeper/msg_server_test.go
+++ b/x/slashing/keeper/msg_server_test.go
@@ -17,10 +17,12 @@ func (s *KeeperTestSuite) TestUpdateParams() {
 	minSignedPerWindow, err := sdkmath.LegacyNewDecFromStr("0.60")
 	require.NoError(err)
 
-	slashFractionDoubleSign, err := sdkmath.LegacyNewDecFromStr("0.022")
+	// NOTE: IF-FINDING-002 Set slash fraction double sign to default value 0
+	slashFractionDoubleSign, err := sdkmath.LegacyNewDecFromStr("0")
 	require.NoError(err)
 
-	slashFractionDowntime, err := sdkmath.LegacyNewDecFromStr("0.0089")
+	// NOTE: IF-FINDING-002 Set slash fraction downtime to default value 0
+	slashFractionDowntime, err := sdkmath.LegacyNewDecFromStr("0")
 	require.NoError(err)
 
 	invalidVal, err := sdkmath.LegacyNewDecFromStr("-1")

--- a/x/slashing/types/params.go
+++ b/x/slashing/types/params.go
@@ -15,8 +15,8 @@ const (
 
 var (
 	DefaultMinSignedPerWindow      = math.LegacyNewDecWithPrec(5, 1)
-	DefaultSlashFractionDoubleSign = math.LegacyNewDec(1).Quo(math.LegacyNewDec(20))
-	DefaultSlashFractionDowntime   = math.LegacyNewDec(1).Quo(math.LegacyNewDec(100))
+	DefaultSlashFractionDoubleSign = math.LegacyNewDec(0)
+	DefaultSlashFractionDowntime   = math.LegacyNewDec(0)
 )
 
 // NewParams creates a new Params object
@@ -125,6 +125,10 @@ func validateSlashFractionDoubleSign(i interface{}) error {
 		return fmt.Errorf("double sign slash fraction too large: %s", v)
 	}
 
+	if !v.IsZero() {
+		return fmt.Errorf("double sign slash fraction must be zero: %s", v)
+	}
+
 	return nil
 }
 
@@ -142,6 +146,10 @@ func validateSlashFractionDowntime(i interface{}) error {
 	}
 	if v.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("downtime slash fraction too large: %s", v)
+	}
+
+	if !v.IsZero() {
+		return fmt.Errorf("downtime sign slash fraction must be zero: %s", v)
 	}
 
 	return nil

--- a/x/slashing/types/params.go
+++ b/x/slashing/types/params.go
@@ -125,6 +125,7 @@ func validateSlashFractionDoubleSign(i interface{}) error {
 		return fmt.Errorf("double sign slash fraction too large: %s", v)
 	}
 
+	// NOTE: IF-FINDING-002 Assert that the double sign slash fraction is zero
 	if !v.IsZero() {
 		return fmt.Errorf("double sign slash fraction must be zero: %s", v)
 	}
@@ -148,6 +149,7 @@ func validateSlashFractionDowntime(i interface{}) error {
 		return fmt.Errorf("downtime slash fraction too large: %s", v)
 	}
 
+	// NOTE: IF-FINDING-002 Assert that the downtime slash fraction is zero
 	if !v.IsZero() {
 		return fmt.Errorf("downtime sign slash fraction must be zero: %s", v)
 	}


### PR DESCRIPTION
# [IF-FINDING-002] Slashing parameters can be modified to unexpected values

## Description

In a Proof of Authority (PoA) system, validator power should remain unchanged after slashing events. If power reductions occur due to slashing, validators may end up with different staking powers, potentially violating the StakingPowerInvariant.
The Keeper Dependencies Parameters Invariant, which expects critical slashing parameters to be initialized to predefined values, does not hold. This is because the slashing parameters SlashFractionDoubleSign and SlashFractionDowntime can be modified through governance or set at genesis to unexpected values.


## Problem scenarios 

- Validators may lose power unexpectedly if slashing parameters are modified post-genesis.
- This could disrupt validator selection and consensus stability, especially in a PoA system where equal power is
expected.

## Recommendation
 
Implement restrictions on parameter changes through both governance and genesis configuration. This can be achieved by modifying the Cosmos SDK fork to prevent governance proposals from updating slashing factor parameters, and by adding genesis initialization checks that validate these values are non-zero before allowing chain startup.

## Applied changes

- Modified the validate params function and added default values to 0